### PR TITLE
Fix overriding $select variable

### DIFF
--- a/web/ajax-multict-select-field.js
+++ b/web/ajax-multict-select-field.js
@@ -58,7 +58,6 @@
                     delay         : 500,
                     type          : 'POST',
                     data          : function (params) {
-                        $select = $(this);
                         var $container = $select.closest('.js-ajax-multi-ct-select-container');
                         return {
                             q    : params.term, // search term


### PR DESCRIPTION
After variable has been overwritten, 'field' was not sent via ajax, so every request returned empty response.