### PR TITLE
Fix saving order of selected options

### DIFF
--- a/web/ajax-multict-select-field.js
+++ b/web/ajax-multict-select-field.js
@@ -34,7 +34,7 @@
             $select     = $buicSelect.find('select');
             options     = $select.data('select2').options.options;
 
-            $select.select2({
+            $select.select2sortable({
                 language                : {
                     errorLoading : function () {
                         return 'Searching...';


### PR DESCRIPTION
Reordered positions haven't got saved.
Bolt already uses select2sortable plugin.